### PR TITLE
Python compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,24 @@
 language: python
-python:
-  - "3.6"
-  - "3.7"
+cache: pip
 install:
   - pip install --upgrade pip setuptools tox twine
-script:
-  - tox
-  - git diff --exit-code
 jobs:
   include:
+    - python: "2.7"
+      script:
+        - tox -e py2-test
+    - python: "3.5"
+      script:
+        - tox -e test -- test_js_regex.py
+    - python: "3.6"
+      script:
+        - tox
+        - git diff --exit-code
+    - python: "3.7"
+      script:
+        - tox
+        - git diff --exit-code
     - stage: publish
+      python: "3.6"
       if: branch = master AND repo = Zac-HD/js-regex
       script: python setup.py sdist bdist_wheel && twine upload --skip-existing dist/*

--- a/deps/check.txt
+++ b/deps/check.txt
@@ -5,8 +5,8 @@
 #    pip-compile --output-file=deps/check.txt deps/check.in
 #
 appdirs==1.4.3            # via black
-astroid==2.2.5            # via pylint
-attrs==19.1.0             # via black
+astroid==2.3.1            # via pylint
+attrs==19.2.0             # via black
 autoflake==1.3.1
 bandit==1.6.2
 black==19.3b0
@@ -14,22 +14,22 @@ click==7.0                # via black
 colorama==0.4.1           # via bandit, pylint
 entrypoints==0.3          # via flake8
 flake8==3.7.8
-gitdb2==2.0.5             # via gitpython
-gitpython==3.0.2          # via bandit
+gitdb2==2.0.6             # via gitpython
+gitpython==3.0.3          # via bandit
 isort==4.3.21
 lazy-object-proxy==1.4.2  # via astroid
 mccabe==0.6.1             # via flake8, pylint
 mypy-extensions==0.4.1    # via mypy
-mypy==0.720
-pbr==5.4.2                # via stevedore
+mypy==0.730
+pbr==5.4.3                # via stevedore
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via autoflake, flake8
-pylint==2.3.1
-pyupgrade==1.23.0
+pylint==2.4.2
+pyupgrade==1.24.0
 pyyaml==5.1.2             # via bandit
 six==1.12.0               # via astroid, bandit, stevedore
 smmap2==2.0.5             # via gitdb2
-stevedore==1.30.1         # via bandit
+stevedore==1.31.0         # via bandit
 tokenize-rt==3.2.0        # via pyupgrade
 toml==0.10.0              # via black
 typed-ast==1.4.0          # via astroid, mypy

--- a/deps/test.in
+++ b/deps/test.in
@@ -2,3 +2,10 @@
 pytest
 pytest-cov
 pytest-xdist
+
+# Pytest has conditional dependencies, but pip-compile does not
+# propagate or even preserve the conditions on transitive dependencies.
+pathlib2>=2.2.0             # ;python_version<"3.6"  # not included in .txt if compiled with Python 3.6
+colorama                    ;sys_platform=="win32"
+importlib-metadata>=0.12    ;python_version<"3.8"
+zipp                        ;python_version<"3.8"  # via importlib-metadata, itself via pytest

--- a/deps/test.txt
+++ b/deps/test.txt
@@ -7,12 +7,13 @@
 apipkg==1.5               # via execnet
 atomicwrites==1.3.0       # via pytest
 attrs==19.2.0             # via pytest
-colorama==0.4.1           # via pytest
+colorama==0.4.1 ; sys_platform == "win32"
 coverage==4.5.4           # via pytest-cov
 execnet==1.7.1            # via pytest-xdist
-importlib-metadata==0.23  # via pluggy, pytest
+importlib-metadata==0.23 ; python_version < "3.8"
 more-itertools==7.2.0     # via pytest, zipp
 packaging==19.2           # via pytest
+pathlib2==2.3.5
 pluggy==0.13.0            # via pytest
 py==1.8.0                 # via pytest
 pyparsing==2.4.2          # via packaging
@@ -20,6 +21,6 @@ pytest-cov==2.7.1
 pytest-forked==1.0.2      # via pytest-xdist
 pytest-xdist==1.30.0
 pytest==5.2.0
-six==1.12.0               # via packaging, pytest-xdist
+six==1.12.0               # via packaging, pathlib2, pytest-xdist
 wcwidth==0.1.7            # via pytest
-zipp==0.6.0               # via importlib-metadata
+zipp==0.6.0 ; python_version < "3.8"

--- a/deps/test.txt
+++ b/deps/test.txt
@@ -6,20 +6,20 @@
 #
 apipkg==1.5               # via execnet
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via packaging, pytest
+attrs==19.2.0             # via pytest
 colorama==0.4.1           # via pytest
 coverage==4.5.4           # via pytest-cov
 execnet==1.7.1            # via pytest-xdist
-importlib-metadata==0.19  # via pluggy, pytest
+importlib-metadata==0.23  # via pluggy, pytest
 more-itertools==7.2.0     # via pytest, zipp
-packaging==19.1           # via pytest
-pluggy==0.12.0            # via pytest
+packaging==19.2           # via pytest
+pluggy==0.13.0            # via pytest
 py==1.8.0                 # via pytest
 pyparsing==2.4.2          # via packaging
 pytest-cov==2.7.1
 pytest-forked==1.0.2      # via pytest-xdist
-pytest-xdist==1.29.0
-pytest==5.1.2
+pytest-xdist==1.30.0
+pytest==5.2.0
 six==1.12.0               # via packaging, pytest-xdist
 wcwidth==0.1.7            # via pytest
 zipp==0.6.0               # via importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ import os
 import setuptools
 
 
-def local_file(name: str) -> str:
+def local_file(name):
+    # type: (str) -> str
     """Interpret filename as relative to this file."""
     return os.path.relpath(os.path.join(os.path.dirname(__file__), name))
 
@@ -32,7 +33,7 @@ setuptools.setup(
     description="A thin compatibility layer to use Javascript regular expressions in Python",
     zip_safe=False,
     install_requires=[],
-    python_requires=">=3.6",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/test_js_regex.py
+++ b/test_js_regex.py
@@ -23,8 +23,8 @@ import js_regex
 )
 def test_expected_transforms(pattern, good_match, bad_match):
     regex = js_regex.compile(pattern)
-    assert regex.match(good_match)
-    assert not regex.match(bad_match)
+    assert regex.search(good_match)
+    assert not regex.search(bad_match)
 
 
 @pytest.mark.parametrize(
@@ -40,11 +40,11 @@ def test_expected_transforms(pattern, good_match, bad_match):
 )
 def test_charclass_transforms(pattern, good_match, bad_match):
     regex = js_regex.compile(pattern)
-    assert regex.match(good_match)
-    assert not regex.match(bad_match)
+    assert regex.search(good_match)
+    assert not regex.search(bad_match)
     if ord(bad_match) >= 128:
-        # Non-ascii string is matched by Python, but not in JS mode
-        assert re.compile(pattern).match(bad_match)
+        # Non-ascii string is matched by Python 3, but not in JS mode
+        assert re.compile(pattern).search(bad_match)
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,9 @@ deps =
     --no-deps
     --requirement deps/deps.txt
 commands =
-    pip-compile --rebuild --output-file=deps/check.txt deps/check.in
-    pip-compile --rebuild --output-file=deps/deps.txt deps/deps.in
-    pip-compile --rebuild --output-file=deps/test.txt deps/test.in setup.py
+    pip-compile --quiet --rebuild --upgrade --output-file=deps/check.txt deps/check.in
+    pip-compile --quiet --rebuild --upgrade --output-file=deps/deps.txt deps/deps.in
+    pip-compile --quiet --rebuild --upgrade --output-file=deps/test.txt deps/test.in setup.py
 
 
 # Settings for other tools

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
 whitelist_externals = bash
 commands =
     autoflake --recursive --in-place --remove-all-unused-imports --remove-duplicate-keys --remove-unused-variables .
-    bash -c \"pyupgrade --py36-plus **.py\"
+    bash -c \"pyupgrade **.py\"
     isort --quiet --recursive --apply .
     black --quiet .
     flake8
@@ -25,6 +25,14 @@ deps =
     --requirement deps/test.txt
 commands =
     pytest {posargs}
+
+[testenv:py2-test]
+description = Test Python 2.7 until https://pythonclock.org/ hits zero
+deps =
+    pytest
+    pytest-cov
+commands =
+    pytest {posargs} test_js_regex.py
 
 # Run `tox -e deps` to update pinned dependencies
 [testenv:deps]

--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,12 @@ whitelist_externals = bash
 commands =
     autoflake --recursive --in-place --remove-all-unused-imports --remove-duplicate-keys --remove-unused-variables .
     bash -c \"pyupgrade --py36-plus **.py\"
-    isort --recursive --apply .
-    black .
+    isort --quiet --recursive --apply .
+    black --quiet .
     flake8
     pylint --disable=all --enable=function-redefined --score=no src/hypothesis_jsonschema test_hypothesis_jsonschema.py
     mypy --config-file=tox.ini . src/
-    bandit --recursive --exclude=./.tox/** --skip=B101,B110,B310 --quiet .
+    bandit --quiet --recursive --exclude=./.tox/** --skip=B101,B110,B310 .
 
 [testenv:test]
 description = Runs pytest with posargs - `tox -e test -- -v` == `pytest -v`
@@ -64,6 +64,7 @@ line_length = 88
 [mypy]
 python_version = 3.6
 platform = linux
+error_summary = False
 disallow_untyped_calls = True
 disallow_untyped_defs = True
 disallow_untyped_decorators = True


### PR DESCRIPTION
Because support for older Pythons will allow `jsonschema` to depend on `js-regex`, however little I like writing Python-2 compatible code.  Thank goodness for `from __future__ import unicode_literals`!