### PR TITLE
add README.md and LICENSE to the sdist

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+description-file = README.md
+license_file = LICENSE


### PR DESCRIPTION
Downstream packagers cannot package this without the license file in the source distribution. I also added the README.md for completeness.